### PR TITLE
Enhance side menus 2

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -386,6 +386,14 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     return self.edgeThresholdEnabled;
   };
 
+  $scope.closeMenuOnTap = true;
+  self.closeMenuOnTap = function(closeMenu) {
+    if (arguments.length) {
+      $scope.closeMenuOnTap = !!closeMenu;
+    }
+    return $scope.closeMenuOnTap;
+  };
+
   self.isDraggableTarget = function(e) {
     //Only restrict edge when sidemenu is closed and restriction is enabled
     var shouldOnlyAllowEdgeDrag = self.edgeThresholdEnabled && !self.isOpen();

--- a/js/angular/directive/sideMenuContent.js
+++ b/js/angular/directive/sideMenuContent.js
@@ -13,7 +13,8 @@
  * ```html
  * <ion-side-menu-content
  *   edge-drag-threshold="true"
- *   drag-content="true">
+ *   drag-content="true"
+ *   close-menu-on-tap="true">
  * </ion-side-menu-content>
  * ```
  * For a complete side menu example, see the
@@ -24,6 +25,7 @@
    *  - If a non-zero number is given, that many pixels is used as the maximum allowed distance from the edge that starts dragging the side menu.
    *  - If true is given, the default number of pixels (25) is used as the maximum allowed distance.
    *  - If false or 0 is given, the edge drag threshold is disabled, and dragging from anywhere on the content is allowed.
+ * @param {boolean=} close-menu-on-tap Whether the content tap should close side menus.  Default true.
  *
  */
 IonicModule
@@ -59,9 +61,15 @@ function($timeout, $ionicGesture, $window) {
           });
         }
 
+        if (isDefined(attr.closeMenuOnTap)) {
+          $scope.$watch(attr.closeMenuOnTap, function(value) {
+            sideMenuCtrl.closeMenuOnTap(value);
+          });
+        }
+
         // Listen for taps on the content to close the menu
         function onContentTap(gestureEvt) {
-          if (sideMenuCtrl.getOpenAmount() !== 0) {
+          if (sideMenuCtrl.closeMenuOnTap() && sideMenuCtrl.getOpenAmount() !== 0) {
             sideMenuCtrl.close();
             gestureEvt.gesture.srcEvent.preventDefault();
             startCoord = null;

--- a/test/unit/angular/directive/sideMenu.unit.js
+++ b/test/unit/angular/directive/sideMenu.unit.js
@@ -219,6 +219,20 @@ describe('Ionic Angular Side Menu', function() {
 
   }));
 
+  it('should closeMenuOnTap', inject(function($compile, $rootScope) {
+    var el = $compile('<ion-side-menus><div ion-side-menu-content></div></ion-side-menus>')($rootScope.$new());
+    $rootScope.$apply();
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(true);
+    expect(el.scope().closeMenuOnTap).toBe(true);
+
+    el.controller('ionSideMenus').closeMenuOnTap(false);
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(false);
+    expect(el.scope().closeMenuOnTap).toBe(false);
+
+    el.controller('ionSideMenus').closeMenuOnTap(true);
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(true);
+    expect(el.scope().closeMenuOnTap).toBe(true);
+  }));
 });
 
 describe('Ionic Side Menu Content Directive', function () {


### PR DESCRIPTION
#### Short description of what this resolves:

This is useful when you don't want to close the menu when users tap on main content.
#### Changes proposed in this pull request:
- added attribute "close-menu-on-tap" to "ion-side-menu-content" directive

**Ionic Version**: 1.x
