### PR TITLE
fix(menu): proper setting of leftShowing flag

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -205,7 +205,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     self.content.setTranslateX(amount);
 
     if (amount >= 0) {
-      leftShowing = true;
+      leftShowing = amount > 0;
       rightShowing = false;
 
       if (amount > 0) {


### PR DESCRIPTION
#### Short description of what this resolves:

Sets leftShowing flag in SideMenuController only when amount of showing menu is greater than zero
#### Changes proposed in this pull request:
- optimized settings of leftShowing and rightShowing flags in SideMenuController

**Ionic Version**: 1.x
